### PR TITLE
timeout connecting to redis

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -53,8 +53,7 @@ func NewRedisDB(c RedisConfig) *RedisDB {
 		Username:    c.Usr,
 		Password:    c.Pwd,
 		DB:          c.DB,
-		DialTimeout: -1,
-		ReadTimeout: -1,
+		DialTimeout: time.Second * 5,
 	})
 
 	if c.TTL == 0 {
@@ -195,7 +194,7 @@ func (s *storage) refresh() {
 
 	for {
 		// time.Sleep(time.Duration(rfshPeriod) * time.Hour)
-		time.Sleep(time.Minute * 5)
+		time.Sleep(time.Minute)
 		s.Lock()
 		start := time.Now()
 		s.cache, err = s.db.GetChecks(ctx)

--- a/storage.go
+++ b/storage.go
@@ -54,6 +54,7 @@ func NewRedisDB(c RedisConfig) *RedisDB {
 		Password:    c.Pwd,
 		DB:          c.DB,
 		DialTimeout: -1,
+		ReadTimeout: -1,
 	})
 
 	if c.TTL == 0 {

--- a/storage.go
+++ b/storage.go
@@ -198,9 +198,10 @@ func (s *storage) refresh() {
 		start := time.Now()
 		s.cache, err = s.db.GetChecks(ctx)
 		if err != nil {
-			s.log.Errorf("error refreshing remote checks: %v", err)
+			s.log.Errorf("error refreshing remote checks in %s: %v", time.Since(start), err)
+		} else {
+			s.log.Debugf("Refreshed %d remote checks in %s", len(s.cache), time.Since(start))
 		}
-		s.log.Debugf("Refreshed %d remote checks in %s", len(s.cache), time.Since(start))
 		s.Unlock()
 	}
 }


### PR DESCRIPTION
Looks like after upgrading to go-redis v9 we are suffering from timeouts at container start.
The container is restarted once and after that it works properly.

I found this https://redis.uptrace.dev/guide/go-redis.html#dial-tcp-i-o-timeout suggesting a delay in the connections could happen running with istio, it's not our case but running in k8s could still matter.

I tested with 5s dial timeout with no luck. After testing with 10s it works (but It's weird that when setup a timeout of 10s it just finishes in roughly 5s).

```
stream time="2023-09-19T12:25:10Z" level=debug msg="Loaded 0 remote checks in 5.007919218s" app=VULCAN-STREAM

stream time="2023-09-19T12:23:36Z" level=debug msg="Loaded 3 remote checks in 5.010317034s" app=VULCAN-STREAM
```

Other solution could be to explore the use of a retryier.

This pr also adds more info to the logs.

BTW: I see this component is caching the info from Redis, this implies this component can not be scaled-out without proper adjustments.